### PR TITLE
refatorar o Modal

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -28,14 +28,13 @@ export default function Home() {
           setModalState(false);
         }}
       >
-        {(propsDoModal) => (
-          // eslint-disable-next-line react/jsx-props-no-spreading
+
+        {/* // eslint-disable-next-line react/jsx-props-no-spreading
           // <Box backgroundColor="white" {...propsDoModal}>
           //   <div>Nosso conteúdo pro modal</div>
-          // </Box>
+          // </Box> */}
 
-          <FormCadastro propsDoModal={propsDoModal} />
-        )}
+        <FormCadastro />
       </Modal>
 
       <Menu />

--- a/src/components/commons/Modal/index.js
+++ b/src/components/commons/Modal/index.js
@@ -67,8 +67,14 @@ function Modal({ isOpen, onClose, children }) {
         }}
         style={{ display: 'flex', flex: 1 }}
       >
-        {children({
+        {/* {children({
           'data-modal-safe-area': 'true',
+        })}
+         */}
+        {React.cloneElement(children, {
+          propsDoModal: {
+            'data-modal-safe-area': true,
+          },
         })}
       </motion.div>
     </ModalWrapper>


### PR DESCRIPTION
Essa mudança tem como objetivo mudar a API do Modal.

O `Children` do Modal, que antes era obrigatoriamente uma função, agora pode ser um componente comum. A injeção da propriedade `data-modal-safe-area` agora é feita pelo `React.cloneElement`.

Em código:
```
<Modal>
    {(propsDoModal) => <ConteudoModal propsDoModal={propsDoModal} />}
</Modal>
```

Agora pode ser substituido por:
```
<Modal>
   <ConteudoModal />
</Modal>
```